### PR TITLE
chore: remove extraneous dependencies

### DIFF
--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -12,9 +12,7 @@
         "@gomomento-poc/node-redis-client": "0.2.0",
         "@redis/client": "^1.5.6",
         "@types/commander": "^2.12.2",
-        "@types/uuid": "^9.0.1",
-        "commander": "^10.0.0",
-        "uuid": "^9.0.0"
+        "commander": "^10.0.0"
       },
       "devDependencies": {
         "@types/node": "14.18.3",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -32,12 +32,10 @@
     "node": ">= 14"
   },
   "dependencies": {
+    "@gomomento-poc/node-redis-client": "0.2.0",
     "@redis/client": "^1.5.6",
     "@types/commander": "^2.12.2",
-    "@types/uuid": "^9.0.1",
-    "commander": "^10.0.0",
-    "@gomomento-poc/node-redis-client": "0.2.0",
-    "uuid": "^9.0.0"
+    "commander": "^10.0.0"
   },
   "prettier": {
     "bracketSpacing": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@gomomento/sdk": "^1.8.0",
-        "@redis/client": "^1.5.6",
-        "@types/commander": "^2.12.2",
-        "@types/uuid": "^9.0.1",
-        "commander": "^10.0.0",
-        "uuid": "^9.0.0"
+        "@redis/client": "^1.5.6"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "@types/node": "14.18.3",
+        "@types/uuid": "^9.0.4",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^7.32.0",
@@ -33,7 +30,8 @@
         "prettier": "^2.4.1",
         "ts-jest": "^29.0.5",
         "ts-node": "^10.3.0",
-        "typescript": "^4.4.3"
+        "typescript": "^4.4.3",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">= 14"
@@ -1459,15 +1457,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
-      "deprecated": "This is a stub types definition for commander (https://github.com/tj/commander.js). commander provides its own type definitions, so you don't need @types/commander installed!",
-      "dependencies": {
-        "commander": "*"
-      }
-    },
     "node_modules/@types/google-protobuf": {
       "version": "3.15.5",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz",
@@ -1557,9 +1546,10 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
+      "version": "9.0.4",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com/npm/npm-upstream/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -2359,14 +2349,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/commander": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -6132,9 +6114,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com/npm/npm-upstream/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7486,14 +7473,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
-      "requires": {
-        "commander": "*"
-      }
-    },
     "@types/google-protobuf": {
       "version": "3.15.5",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz",
@@ -7583,9 +7562,10 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
+      "version": "9.0.4",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com/npm/npm-upstream/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.24",
@@ -8118,11 +8098,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "commander": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -10861,9 +10836,10 @@
       }
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "9.0.1",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com/npm/npm-upstream/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@types/node": "14.18.3",
+    "@types/uuid": "^9.0.4",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^7.32.0",
@@ -36,18 +37,15 @@
     "prettier": "^2.4.1",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.3.0",
-    "typescript": "^4.4.3"
+    "typescript": "^4.4.3",
+    "uuid": "^9.0.1"
   },
   "engines": {
     "node": ">= 14"
   },
   "dependencies": {
     "@gomomento/sdk": "^1.8.0",
-    "@redis/client": "^1.5.6",
-    "@types/commander": "^2.12.2",
-    "commander": "^10.0.0",
-    "@types/uuid": "^9.0.1",
-    "uuid": "^9.0.0"
+    "@redis/client": "^1.5.6"
   },
   "prettier": {
     "bracketSpacing": false,


### PR DESCRIPTION
There were some depeendencies listed that were not prod
dependencoes. They were either dev dependencies (eg uuid, for testing)
or example dependencies (commander). We remove commander from the main
project and move uuid to a test dependency. In the basic example we
remove uuid as a dependency.
