### PR TITLE
chore: stop using macos CI runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     name: Test on Node ${{ matrix.node }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: js-redis-client-test-ci

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
   publish_javascript:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: js-redis-client-test-ci


### PR DESCRIPTION
In the past, we had issues with ubuntu runners in certain situations and were forced to use macos, which is much more expensive. Those issues have now been resolved on the Azure/github side, so we can switch back to ubuntu to reduce costs.
